### PR TITLE
Move block texture to 5, use 0 for nanogui.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -333,7 +333,7 @@ private:
     void handle_texture(konstructs::Packet *packet) {
         GLuint texture;
         glGenTextures(1, &texture);
-        glActiveTexture(GL_TEXTURE0);
+        glActiveTexture(GL_TEXTURE5);
         glBindTexture(GL_TEXTURE_2D, texture);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -415,6 +415,7 @@ private:
         using namespace nanogui;
 
         glfwSetInputMode(mGLFWWindow, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+        glActiveTexture(GL_TEXTURE0);
 
         window = new Window(this, "Main Menu");
         window->setLayout(new GroupLayout());

--- a/src/textures.h
+++ b/src/textures.h
@@ -1,7 +1,7 @@
 #ifndef __TEXTURES_H__
 #define __TEXTURES_H__
 namespace konstructs {
-    #define BLOCK_TEXTURES 0
+    #define BLOCK_TEXTURES 5
     #define SKY_TEXTURE 2
     #define FONT_TEXTURE 3
     #define INVENTORY_TEXTURE 4


### PR DESCRIPTION
I was unable to get NanoGUI to use texture 5, so I moved the block texture to 5.

Looks like something in `init_menu()` overwrote something in the active texture, so, I changed back to texture 0.

![screenshot from 2015-12-26 21 06 38](https://cloud.githubusercontent.com/assets/16388/12007797/5da0c9c6-ac15-11e5-99c8-c2d5230fd572.png)
