### PR TITLE
Transparent hud

### DIFF
--- a/src/hud_shader.cpp
+++ b/src/hud_shader.cpp
@@ -181,7 +181,7 @@ namespace konstructs {
             "    if (color == vec3(1.0, 0.0, 1.0)) {\n"
             "        discard;\n"
             "    }\n"
-            "    fragColor = vec4(color, 1.0);\n"
+            "    fragColor = vec4(color, 0.6);\n"
             "}\n"),
         position(attributeId("position")),
         uv(attributeId("uv")),
@@ -224,6 +224,8 @@ namespace konstructs {
                 float xscale = (float)height / (float)width;
                 float screen_area = 0.6;
 
+                c.blend_func(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
                 /* Set up for 17 x 14 HUD grid */
                 c.set(matrix,  hud_translation_matrix(scale, xscale, screen_area));
                 c.set(offset, hud_offset_vector(xscale, screen_area));
@@ -233,7 +235,9 @@ namespace konstructs {
 
                 /* Generate and draw background model */
                 HudModel hm(hud.backgrounds(), position, uv);
+                c.enable(GL_BLEND);
                 c.draw(hm);
+                c.disable(GL_BLEND);
 
                 /* Use block texture */
                 c.set(sampler, block_texture);
@@ -246,7 +250,9 @@ namespace konstructs {
 
                 /* Generate and draw item stack amounts */
                 AmountModel am(position, uv, hud.stacks());
+                c.enable(GL_BLEND);
                 c.draw(am);
+                c.disable(GL_BLEND);
 
                 /* Check for held block*/
                 auto held = hud.held();

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -131,6 +131,10 @@ namespace konstructs {
         glDisable(cap);
     }
 
+    void Context::blend_func(const GLenum sfactor, const GLenum dfactor) {
+        glBlendFunc(sfactor, dfactor);
+    }
+
     BufferModel::~BufferModel() {
         glDeleteBuffers(1, &buffer);
     }

--- a/src/shader.h
+++ b/src/shader.h
@@ -67,6 +67,7 @@ namespace konstructs {
         void logic_op(const GLenum opcode);
         void enable(const GLenum cap);
         void disable(const GLenum cap);
+        void blend_func(const GLenum sfactor, const GLenum dfactor);
     private:
         const GLenum draw_mode;
     };


### PR DESCRIPTION
![screenshot from 2015-12-28 01 16 03](https://cloud.githubusercontent.com/assets/16388/12012691/12643e24-ad01-11e5-901b-fcbac2e15261.png)

Not sure what I think about this, but it was easy and no need to add extra data to the shader.
Basically, the `0.6` value will only matter if we have enabled `GL_BLEND` so I turned it on/off whenever I liked something to be transparent :)

@petterarvidsson what do you think, is this acceptable? At least, I like the transparent look. At the moment it's at 60%, I think it was a little higher, maybe 0.7 or 0.8 in the old client.