### PR TITLE
Do not render selected block, if the inventory or menu is open.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -193,7 +193,7 @@ public:
         glClear(GL_DEPTH_BUFFER_BIT);
         int faces = chunk_shader.render(player, mSize.x(), mSize.y(),
                                         daylight(), time_of_day());
-        if(looking_at) {
+        if(looking_at && !hud_interaction && !menu_state) {
             selection_shader.render(player, mSize.x(), mSize.y(),
                                     looking_at->second.position);
         }


### PR DESCRIPTION
I noticed this when we started to render partly transparent inventories.

It looks a little ugly with the selection_shader render behind the inventory, so this PR hides it when either the menu or hud iteration/inventory is active.