### PR TITLE
Print out OpenGL info on start.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,6 +70,12 @@ public:
         menu_state(0) {
 
         using namespace nanogui;
+
+        printf("OpenGL vendor: %s\n", glGetString(GL_VENDOR));
+        printf("OpenGL version: %s\n", glGetString(GL_VERSION));
+        printf("OpenGL renderer: %s\n", glGetString(GL_RENDERER));
+        printf("OpenGL extensions: %s\n", glGetString(GL_EXTENSIONS));
+
         performLayout(mNVGContext);
         glfwSetInputMode(mGLFWWindow, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
         if (nick.size() > 0 && hash.size() > 0 && hostname.size() > 0) {


### PR DESCRIPTION
Quick hack to display the OpenGL version, GFX and so on ....

```
$ ./konstructs
OpenGL vendor: NVIDIA Corporation
OpenGL version: 3.3.0 NVIDIA 340.96
OpenGL renderer: GeForce GTX 780/PCIe/SSE2
OpenGL extensions: (null)
```

... I'm not sure that this will work if nanogui fails to initialize the opengl 3.3 context. A better solution is probably to add this when we open the opengl context _inside_ nanogui. Not sure that I like the idea to continue adding/changing code in our fork.