### PR TITLE
This stops rendering of held items when hud is closed

### DIFF
--- a/src/hud_shader.cpp
+++ b/src/hud_shader.cpp
@@ -239,7 +239,7 @@ namespace konstructs {
 
                 /* Check for held block*/
                 auto held = hud.held();
-                if(held) {
+                if(held && hud.get_interactive()) {
 
                     /* Calculate mouse position on screen as gl coordinates */
                     float x = (mouse_x / (float)width) * 2.0f - 1.0f;


### PR DESCRIPTION
- The server could decide to reinsert the held stack into the inventory