### PR TITLE
Fix head inside blocks bug

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,7 +134,7 @@ public:
                 auto &l = *looking_at;
                 if(button == GLFW_MOUSE_BUTTON_1 && down) {
                     client.click_at(1, l.second.position, translate_button(button), hud.get_selection());
-                } else if(button == GLFW_MOUSE_BUTTON_2 && down) {
+                } else if(button == GLFW_MOUSE_BUTTON_2 && down && player.can_place(l.first.position, world, blocks)) {
                     optional<ItemStack> selected = hud.selected();
                     if(selected) {
                         std::shared_ptr<ChunkData> updated_chunk =

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #define KONSTRUCTS_KEY_RIGHT 'D'
 #define KONSTRUCTS_KEY_JUMP GLFW_KEY_SPACE
 #define KONSTRUCTS_KEY_FLY GLFW_KEY_TAB
+#define KONSTRUCTS_KEY_SNEAK GLFW_KEY_LEFT_SHIFT
 #define KONSTRUCTS_KEY_INVENTORY 'E'
 using std::cout;
 using std::cerr;
@@ -273,6 +274,7 @@ private:
         int sx = 0;
         int sz = 0;
         bool jump = false;
+        bool sneak = false;
         double now = glfwGetTime();
         double dt = now - last_frame;
         dt = MIN(dt, 0.2);
@@ -294,8 +296,11 @@ private:
         if(glfwGetKey(mGLFWWindow, KONSTRUCTS_KEY_JUMP)) {
             jump = true;
         }
+        if(glfwGetKey(mGLFWWindow, KONSTRUCTS_KEY_SNEAK)) {
+            sneak = true;
+        }
         client.position(player.update_position(sz, sx, (float)dt, world,
-                                               blocks, near_distance, jump),
+                                               blocks, near_distance, jump, sneak),
                         player.rx(), player.ry());
     }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -43,6 +43,26 @@ namespace konstructs {
         return vec;
     }
 
+    Vector3i Player::feet() const {
+        return Vector3i(roundf(position[0]), roundf(position[1]) - 1, roundf(position[2]));
+    }
+
+    bool Player::can_place(Vector3i block, const World &world, const BlockData &blocks) {
+        Vector3i f = feet();
+        /* Are we trying to place blocks on ourselves? */
+        if(block(0) == f(0) && block(2) == f(2) && block(1) >= f(1) && block(1) < f(1) + 2) {
+            /* We may place on our feet under certain circumstances */
+            if(f(1) == block(1)) {
+                /* Allow placing on our feet if the block above our head is not an obstacle*/
+                return !blocks.is_obstacle[world.get_block(Vector3i(f(0), f(1) + 2, f(2)))];
+            } else {
+                /* We are never allowed to place on our head */
+                return false;
+            }
+        }
+        return true;
+    }
+
     Vector3f Player::update_position(int sz, int sx, float dt,
                                      const World &world, const BlockData &blocks,
                                      const float near_distance, const bool jump) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -11,9 +11,9 @@ namespace konstructs {
     static float CAMERA_OFFSET = 0.5f;
     static Vector3f CAMERA_OFFSET_VECTOR = Vector3f(0, CAMERA_OFFSET, 0);
 
-    Player::Player(const int _id, const Vector3f _position, const float _rx,
-                   const float _ry):
-        id(_id), position(_position), mrx(_rx), mry(_ry), flying(false), dy(0) {}
+    Player::Player(const int id, const Vector3f position, const float rx,
+                   const float ry):
+        id(id), position(position), mrx(rx), mry(ry), flying(false), dy(0) {}
 
     Matrix4f Player::direction() const {
         return (Affine3f(AngleAxisf(mrx, Vector3f::UnitX())) *

--- a/src/player.h
+++ b/src/player.h
@@ -25,7 +25,7 @@ namespace konstructs {
         bool can_place(Vector3i block, const World &world, const BlockData &blocks);
         Vector3f update_position(int sz, int sx, float dt,
                                  const World &world, const BlockData &blocks,
-                                 const float near_distance, const bool jump);
+                                 const float near_distance, const bool jump, const bool sneaking);
         optional<pair<Block, Block>> looking_at(const World &world,
                                                 const BlockData &blocks) const;
         void rotate_x(float speed);
@@ -36,7 +36,8 @@ namespace konstructs {
         float ry();
         Vector3f position;
     private:
-        int collide(const World &world, const BlockData &blocks, const float near_distance);
+        int collide(const World &world, const BlockData &blocks,
+                    const float near_distance, const bool sneaking);
         float mrx;
         float mry;
         bool flying;

--- a/src/player.h
+++ b/src/player.h
@@ -21,6 +21,8 @@ namespace konstructs {
         Matrix4f view() const;
         Vector3f camera() const;
         Vector3f camera_direction() const;
+        Vector3i feet() const;
+        bool can_place(Vector3i block, const World &world, const BlockData &blocks);
         Vector3f update_position(int sz, int sx, float dt,
                                  const World &world, const BlockData &blocks,
                                  const float near_distance, const bool jump);

--- a/src/player.h
+++ b/src/player.h
@@ -14,8 +14,8 @@ namespace konstructs {
 
     class Player {
     public:
-        Player(const int _id, const Vector3f _position,
-               const float _rx, const float _ry);
+        Player(const int id, const Vector3f position,
+               const float rx, const float ry);
         Matrix4f direction() const;
         Matrix4f translation() const;
         Matrix4f view() const;

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -44,6 +44,10 @@ namespace konstructs {
         requested.erase(pos);
     }
 
+    const char World::get_block(const Vector3i &block_pos) const {
+        return chunks.at(chunked_vec_int(block_pos))->get(block_pos);
+    }
+
     const std::shared_ptr<ChunkData> World::chunk_at(const Vector3i &block_pos) const {
         return chunks.at(chunked_vec_int(block_pos));
     }

--- a/src/world.h
+++ b/src/world.h
@@ -17,6 +17,7 @@ namespace konstructs {
         bool chunk_updated_since_requested(const Vector3i &pos) const;
         void delete_unused_chunks(const Vector3f position, const int radi);
         void insert(std::shared_ptr<ChunkData> data);
+        const char get_block(const Vector3i &block_pos) const;
         const std::shared_ptr<ChunkData> chunk_at(const Vector3i &block_pos) const;
         const std::shared_ptr<ChunkData> chunk(const Vector3i &chunk_pos) const;
         const std::vector<std::shared_ptr<ChunkData>> atAndAround(const Vector3i &pos) const;


### PR DESCRIPTION
This prevents the player from using the secondary action if the position it is used on is inside the user. The user is allowed to put a block on her feet if the block above the head is not an obstacle.

This fixes #178, #170 