### PR TITLE
Extend block format with health

### DIFF
--- a/src/block.cpp
+++ b/src/block.cpp
@@ -1,6 +1,6 @@
 #include "block.h"
 
 namespace konstructs {
-    Block::Block(const Vector3i _position, const char _type):
-        position(_position), type(_type) {}
+    Block::Block(const Vector3i position, const BlockData data):
+        position(position), data(data) {}
 };

--- a/src/block.h
+++ b/src/block.h
@@ -4,7 +4,9 @@
 #include <Eigen/Geometry>
 
 #define VOID_BLOCK 0
-#define SOLID_BLOCK 100
+#define SOLID_TYPE 65535
+#define BLOCK_TYPES 65536
+#define MAX_HEALTH 2047
 
 #define STATE_SOLID 0
 #define STATE_LIQUID 1
@@ -15,19 +17,24 @@ namespace konstructs {
 
     using namespace Eigen;
 
+    struct BlockTypeInfo {
+        int blocks[BLOCK_TYPES][6];
+        char is_plant[BLOCK_TYPES];
+        char is_obstacle[BLOCK_TYPES];
+        char is_transparent[BLOCK_TYPES];
+        char state[BLOCK_TYPES];
+    };
+
     struct BlockData {
-        int blocks[256][6];
-        char is_plant[256];
-        char is_obstacle[256];
-        char is_transparent[256];
-        char state[256];
+        uint16_t type;
+        uint16_t health;
     };
 
     class Block {
     public:
-        Block(const Vector3i _position, const char _type);
+        Block(const Vector3i position, const BlockData data);
         Vector3i position;
-        char type;
+        BlockData data;
     };
 };
 

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -29,25 +29,32 @@ namespace konstructs {
         return chunked_vec_int(position.cast<int>());
     }
 
-    ChunkData::ChunkData(const Vector3i _position, char *compressed, const int size):
+    ChunkData::ChunkData(const Vector3i _position, char *compressed, const int size, char *buffer):
         position(_position) {
-        blocks = new char[CHUNK_SIZE*CHUNK_SIZE*CHUNK_SIZE];
+        blocks = new BlockData[CHUNK_SIZE*CHUNK_SIZE*CHUNK_SIZE];
         int out_size = inflate_data(compressed + BLOCKS_HEADER_SIZE,
                                     size - BLOCKS_HEADER_SIZE,
-                                    blocks, CHUNK_SIZE*CHUNK_SIZE*CHUNK_SIZE);
+                                    buffer, BLOCK_BUFFER_SIZE);
+        for(int i = 0; i < CHUNK_SIZE*CHUNK_SIZE*CHUNK_SIZE; i++) {
+            blocks[i].type = buffer[i * BLOCK_SIZE] + (buffer[i * BLOCK_SIZE + 1] << 8);
+            blocks[i].health = buffer[i * BLOCK_SIZE + 2] + ((buffer[i * BLOCK_SIZE + 3] << 8) & 0x07);
+        }
     }
     ChunkData::ChunkData() {
-        blocks = new char[CHUNK_SIZE*CHUNK_SIZE*CHUNK_SIZE];
-        memset(blocks, (char)SOLID_BLOCK, CHUNK_SIZE*CHUNK_SIZE*CHUNK_SIZE);
+        blocks = new BlockData[CHUNK_SIZE*CHUNK_SIZE*CHUNK_SIZE];
+        for(int i = 0; i < CHUNK_SIZE*CHUNK_SIZE*CHUNK_SIZE; i++) {
+            blocks[i].type = SOLID_TYPE;
+            blocks[i].health = MAX_HEALTH;
+        }
     }
-    ChunkData::ChunkData(const Vector3i position, char *blocks) :
+    ChunkData::ChunkData(const Vector3i position, BlockData *blocks) :
         position(position), blocks(blocks) {}
 
     ChunkData::~ChunkData() {
         delete[] blocks;
     }
 
-    char ChunkData::get(const Vector3i &pos) const {
+    BlockData ChunkData::get(const Vector3i &pos) const {
         int lx = pos[0] - position[0] * CHUNK_SIZE;
         int ly = pos[1] - position[2] * CHUNK_SIZE;
         int lz = pos[2] - position[1] * CHUNK_SIZE;
@@ -55,21 +62,22 @@ namespace konstructs {
         // TODO: Looking for a block in the wrong chunk is a bit weird, but hit code does it
         if(lx < CHUNK_SIZE && ly < CHUNK_SIZE && lz < CHUNK_SIZE &&
            lx >= 0 && ly >= 0 && lz >= 0) {
-            return blocks[lx+ly*CHUNK_SIZE+lz*CHUNK_SIZE*CHUNK_SIZE];
+            int i = lx+ly*CHUNK_SIZE+lz*CHUNK_SIZE*CHUNK_SIZE;
+            return blocks[i];
         } else {
-            return 0;
+            return {0, 0};
         }
     }
 
-    std::shared_ptr<ChunkData> ChunkData::set(const Vector3i &pos, const char type) const {
+    std::shared_ptr<ChunkData> ChunkData::set(const Vector3i &pos, const BlockData &data) const {
         int lx = pos[0] - position[0] * CHUNK_SIZE;
         int ly = pos[1] - position[2] * CHUNK_SIZE;
         int lz = pos[2] - position[1] * CHUNK_SIZE;
 
-        char *new_blocks = new char[CHUNK_SIZE * CHUNK_SIZE * CHUNK_SIZE];
-        memcpy(new_blocks, blocks, CHUNK_SIZE * CHUNK_SIZE * CHUNK_SIZE);
+        BlockData *new_blocks = new BlockData[CHUNK_SIZE*CHUNK_SIZE*CHUNK_SIZE];
+        memcpy(new_blocks, blocks, CHUNK_SIZE*CHUNK_SIZE*CHUNK_SIZE*sizeof(BlockData));
 
-        new_blocks[lx+ly*CHUNK_SIZE+lz*CHUNK_SIZE*CHUNK_SIZE] = type;
+        new_blocks[lx+ly*CHUNK_SIZE+lz*CHUNK_SIZE*CHUNK_SIZE] = data;
 
         return std::make_shared<ChunkData>(position, new_blocks);
     }
@@ -82,17 +90,17 @@ namespace konstructs {
     optional<pair<Block, Block>> ChunkData::get(const Vector3f &camera_position,
                                                 const Vector3f &camera_direction,
                                                 const float max_distance,
-                                                const BlockData &blocks) const {
+                                                const BlockTypeInfo &blocks) const {
         int m = 4;
         Vector3f pos = camera_position;
         Vector3i blockPos(0,0,0);
         for (int i = 0; i < max_distance * m; i++) {
             const Vector3i nBlockPos(roundf(pos[0]), roundf(pos[1]), roundf(pos[2]));
             if (nBlockPos != blockPos) {
-                char hw = get(nBlockPos);
-                if (blocks.is_obstacle[hw] || blocks.is_plant[hw]) {
-                    return optional<pair<Block, Block>>(pair<Block, Block>(Block(blockPos, hw),
-                                                                           Block(nBlockPos, hw)));
+                BlockData data = get(nBlockPos);
+                if (blocks.is_obstacle[data.type] || blocks.is_plant[data.type]) {
+                    return optional<pair<Block, Block>>(pair<Block, Block>(Block(blockPos, data),
+                                                                           Block(nBlockPos, data)));
                 }
                 blockPos = nBlockPos;
             }

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -7,7 +7,9 @@
 #include "shader.h" //TODO: remove
 #include "block.h"
 
+#define BLOCK_SIZE 4
 #define CHUNK_SIZE 32
+#define BLOCK_BUFFER_SIZE (CHUNK_SIZE*CHUNK_SIZE*CHUNK_SIZE*BLOCK_SIZE)
 #define BLOCKS_HEADER_SIZE 2
 
 namespace konstructs {
@@ -25,71 +27,71 @@ namespace konstructs {
 
     class ChunkData {
     public:
-        ChunkData(const Vector3i _position, char *compressed, const int size);
-        ChunkData(const Vector3i position, char *blocks);
+        ChunkData(const Vector3i _position, char *compressed, const int size, char *buffer);
+        ChunkData(const Vector3i position, BlockData *blocks);
         ChunkData();
         ~ChunkData();
-        char get(const Vector3i &pos) const;
-        std::shared_ptr<ChunkData> set(const Vector3i &pos, const char type) const;
+        BlockData get(const Vector3i &pos) const;
+        std::shared_ptr<ChunkData> set(const Vector3i &pos, const BlockData &data) const;
         optional<pair<Block, Block>> get(const Vector3f &camera_position,
                                          const Vector3f &camera_direction,
                                          const float max_distance,
-                                         const BlockData &blocks) const;
+                                         const BlockTypeInfo &blocks) const;
         const Vector3i position;
-        char *blocks;
+        BlockData *blocks;
     };
 };
 
-#define CHUNK_FOR_EACH(blocks, ex, ey, ez, ew) \
+#define CHUNK_FOR_EACH(blocks, ex, ey, ez, eb) \
   for(int ex = 0; ex < CHUNK_SIZE; ex++) { \
     for(int ey = 0; ey < CHUNK_SIZE; ey++) { \
       for(int ez = 0; ez < CHUNK_SIZE; ez++) { \
-        int ew = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
+        BlockData eb = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
 
 #define END_CHUNK_FOR_EACH \
        } \
      } \
    }
 
-#define CHUNK_FOR_EACH_YZ(blocks, x, ex, ey, ez, ew)     \
+#define CHUNK_FOR_EACH_YZ(blocks, x, ex, ey, ez, eb)     \
   for(int ey = 0; ey < CHUNK_SIZE; ey++) { \
     for(int ez = 0; ez < CHUNK_SIZE; ez++) { \
       int ex = x; \
-      int ew = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
+      BlockData eb = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
 
-#define CHUNK_FOR_EACH_XY(blocks, z, ex, ey, ez, ew)     \
+#define CHUNK_FOR_EACH_XY(blocks, z, ex, ey, ez, eb)     \
   for(int ex = 0; ex < CHUNK_SIZE; ex++) { \
     for(int ey = 0; ey < CHUNK_SIZE; ey++) { \
       int ez = z; \
-      int ew = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
+      BlockData eb = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
 
-#define CHUNK_FOR_EACH_XZ(blocks, y, ex, ey, ez, ew)     \
+#define CHUNK_FOR_EACH_XZ(blocks, y, ex, ey, ez, eb)     \
   for(int ex = 0; ex < CHUNK_SIZE; ex++) { \
     for(int ez = 0; ez < CHUNK_SIZE; ez++) { \
       int ey = y; \
-      int ew = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
+      BlockData eb = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
 
 #define END_CHUNK_FOR_EACH_2D \
      } \
    }
 
-#define CHUNK_FOR_EACH_X(blocks, y, z, ex, ey, ez, ew)   \
+#define CHUNK_FOR_EACH_X(blocks, y, z, ex, ey, ez, eb)   \
   for(int ex = 0; ex < CHUNK_SIZE; ex++) { \
     int ey = y; \
     int ez = z; \
-    int ew = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
+    BlockData eb = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
 
-#define CHUNK_FOR_EACH_Y(blocks, x, z, ex, ey, ez, ew)   \
+#define CHUNK_FOR_EACH_Y(blocks, x, z, ex, ey, ez, eb)   \
   for(int ey = 0; ey < CHUNK_SIZE; ey++) { \
     int ez = z; \
     int ex = x; \
-    int ew = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
+    BlockData eb = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
 
-#define CHUNK_FOR_EACH_Z(blocks, x, y, ex, ey, ez, ew)   \
+#define CHUNK_FOR_EACH_Z(blocks, x, y, ex, ey, ez, eb)   \
   for(int ez = 0; ez < CHUNK_SIZE; ez++) { \
     int ex = x; \
     int ey = y; \
-    int ew = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
+    BlockData eb = blocks[ex+ey*CHUNK_SIZE+ez*CHUNK_SIZE*CHUNK_SIZE];
 
 #define END_CHUNK_FOR_EACH_1D \
   }

--- a/src/chunk_factory.h
+++ b/src/chunk_factory.h
@@ -51,7 +51,7 @@ namespace konstructs {
 
     class ChunkModelFactory {
     public:
-        ChunkModelFactory(const BlockData &_block_data);
+        ChunkModelFactory(const BlockTypeInfo &_block_data);
         void create_models(const std::vector<Vector3i> &positions,
                            const World &world);
         std::vector<std::shared_ptr<ChunkModelResult>> fetch_models();
@@ -62,7 +62,7 @@ namespace konstructs {
         std::queue<Vector3i> chunks;
         std::unordered_map<Vector3i, ChunkModelData, matrix_hash<Vector3i>> model_data;
         std::vector<std::shared_ptr<ChunkModelResult>> models;
-        const BlockData &block_data;
+        const BlockTypeInfo &block_data;
     };
 
     std::vector<ChunkModelData> adjacent(const Vector3i position, const World &world);
@@ -71,6 +71,6 @@ namespace konstructs {
     const ChunkModelData create_model_data(const Vector3i &position,
                                            const World &world);
 
-    shared_ptr<ChunkModelResult> compute_chunk(const ChunkModelData &data, const BlockData &block_data);
+    shared_ptr<ChunkModelResult> compute_chunk(const ChunkModelData &data, const BlockTypeInfo &block_data);
 };
 #endif

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -26,6 +26,7 @@ namespace konstructs {
 
     Client::Client() : connected(false) {
         worker_thread = new std::thread(&Client::recv_worker, this);
+        inflation_buffer = new char[BLOCK_BUFFER_SIZE];
     }
 
     string Client::get_error_message() {
@@ -104,7 +105,7 @@ namespace konstructs {
 
         Vector3i position(p, q, k);
         const int blocks_size = packet->size - 3 * sizeof(int);
-        auto chunk = make_shared<ChunkData>(position, pos, blocks_size);
+        auto chunk = make_shared<ChunkData>(position, pos, blocks_size, inflation_buffer);
         std::unique_lock<std::mutex> ulock_packets(packets_mutex);
         chunks.push_back(chunk);
     }

--- a/src/client.h
+++ b/src/client.h
@@ -76,6 +76,7 @@ namespace konstructs {
         std::deque<shared_ptr<ChunkData>> chunks;
         bool connected;
         std::string error_message;
+        char *inflation_buffer;
     };
 };
 

--- a/src/hud_shader.cpp
+++ b/src/hud_shader.cpp
@@ -16,14 +16,14 @@ namespace konstructs {
 
     void make_block(int type, float x, float y, float z, float size,
                     float rx, float ry, float rz, float *d,
-                    const BlockData &blocks);
+                    const BlockTypeInfo &blocks);
 
     void make_stacks(const std::unordered_map<Vector2i, ItemStack, matrix_hash<Vector2i>> &stacks,
                      float *d,
                      const float rx,
                      const float ry,
                      const float rz,
-                     const BlockData &blocks);
+                     const BlockTypeInfo &blocks);
 
     void make_stack_amounts(const std::unordered_map<Vector2i, ItemStack, matrix_hash<Vector2i>> &stacks, float *d);
 
@@ -54,7 +54,7 @@ namespace konstructs {
     ItemStackModel::ItemStackModel(const GLuint position_attr, const GLuint normal_attr,
                                    const GLuint uv_attr,
                                    const std::unordered_map<Vector2i, ItemStack, matrix_hash<Vector2i>> &stacks,
-                                   const BlockData &blocks) :
+                                   const BlockTypeInfo &blocks) :
         BaseModel(position_attr, normal_attr, uv_attr) {
 
         verts = 0;
@@ -120,7 +120,7 @@ namespace konstructs {
                            const GLuint uv_attr,
                            const int type, const float x, const float y,
                            const float size,
-                           const BlockData &blocks) :
+                           const BlockTypeInfo &blocks) :
         BaseModel(position_attr, normal_attr, uv_attr) {
         verts = blocks.is_plant[type] ? 6 : 6 * 6;
         float *data = new float[verts * 10];
@@ -203,7 +203,7 @@ namespace konstructs {
     void HudShader::render(const int width, const int height,
                            const float mouse_x, const float mouse_y,
                            const Hud &hud,
-                           const BlockData &blocks) {
+                           const BlockTypeInfo &blocks) {
         bind([&](Context c) {
                 float scale = 4.0f/(float)columns;
                 float xscale = (float)height / (float)width;
@@ -336,7 +336,7 @@ namespace konstructs {
 
     void make_block(int type, float x, float y, float z, float size,
                     float rx, float ry, float rz, float *d,
-                    const BlockData &blocks) {
+                    const BlockTypeInfo &blocks) {
         float ao[6][4] = {0};
         float light[6][4] = {
             {0.5, 0.5, 0.5, 0.5},
@@ -364,7 +364,7 @@ namespace konstructs {
                      const float rx,
                      const float ry,
                      const float rz,
-                     const BlockData &blocks) {
+                     const BlockTypeInfo &blocks) {
 
         int offset = 0;
         for (const auto &pair: stacks) {

--- a/src/hud_shader.h
+++ b/src/hud_shader.h
@@ -31,7 +31,7 @@ namespace konstructs {
         ItemStackModel(const GLuint position_attr, const GLuint normal_attr,
                        const GLuint uv_attr,
                        const std::unordered_map<Vector2i, ItemStack, matrix_hash<Vector2i>> &stacks,
-                       const BlockData &blocks);
+                       const BlockTypeInfo &blocks);
     };
 
     class AmountModel : public BaseModel {
@@ -54,7 +54,7 @@ namespace konstructs {
                    const GLuint uv_attr,
                    const int type, const float x, const float y,
                    const float size,
-                   const BlockData &blocks);
+                   const BlockTypeInfo &blocks);
     };
 
     class HudShader: private ShaderProgram {
@@ -66,7 +66,7 @@ namespace konstructs {
         void render(const int width, const int height,
                     const float mouse_x, const float mouse_y,
                     const Hud &hud,
-                    const BlockData &blocks);
+                    const BlockTypeInfo &blocks);
 
     private:
         const GLuint position;

--- a/src/item.h
+++ b/src/item.h
@@ -1,10 +1,12 @@
 #ifndef _ITEM_H_
 #define _ITEM_H_
 
+#include <cstdint>
+
 namespace konstructs {
     struct ItemStack {
         int amount;
-        int type;
+        uint16_t type;
     };
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,10 +90,10 @@ public:
         } else {
             show_menu(string("Connect to a server"));
         }
-        blocks.is_plant[SOLID_BLOCK] = 0;
-        blocks.is_obstacle[SOLID_BLOCK] = 1;
-        blocks.is_transparent[SOLID_BLOCK] = 0;
-        blocks.state[SOLID_BLOCK] = STATE_SOLID;
+        blocks.is_plant[SOLID_TYPE] = 0;
+        blocks.is_obstacle[SOLID_TYPE] = 1;
+        blocks.is_transparent[SOLID_TYPE] = 0;
+        blocks.state[SOLID_TYPE] = STATE_SOLID;
         memset(&fps, 0, sizeof(fps));
 
         tinyobj::shape_t shape = load_player();
@@ -140,7 +140,7 @@ public:
                     if(selected) {
                         std::shared_ptr<ChunkData> updated_chunk =
                             world.chunk_at(l.first.position)->set(l.first.position,
-                                                                  selected->type);
+                                                                  {selected->type, MAX_HEALTH});
                         world.insert(updated_chunk);
                         force_render(updated_chunk->position);
                     }
@@ -470,7 +470,7 @@ private:
         if(size < 1) {
             hud.reset_belt(column);
         } else {
-            hud.set_belt(column, {size, type});
+            hud.set_belt(column, {size, (uint16_t)type});
         }
     }
 
@@ -488,7 +488,7 @@ private:
             hud.reset_stack(pos);
         } else {
             hud.set_background(pos, 2);
-            hud.set_stack(pos, {size, type});
+            hud.set_stack(pos, {size, (uint16_t)type});
         }
     }
 
@@ -500,7 +500,7 @@ private:
         if(type == -1) {
             hud.reset_held();
         } else {
-            hud.set_held({amount, type});
+            hud.set_held({amount, (uint16_t)type});
         }
     }
 
@@ -592,7 +592,7 @@ private:
     std::string hostname;
     std::string username;
     std::string password;
-    BlockData blocks;
+    BlockTypeInfo blocks;
     CrosshairShader crosshair_shader;
     int radius;
     int fov;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -47,14 +47,14 @@ namespace konstructs {
         return Vector3i(roundf(position[0]), roundf(position[1]) - 1, roundf(position[2]));
     }
 
-    bool Player::can_place(Vector3i block, const World &world, const BlockData &blocks) {
+    bool Player::can_place(Vector3i block, const World &world, const BlockTypeInfo &blocks) {
         Vector3i f = feet();
         /* Are we trying to place blocks on ourselves? */
         if(block(0) == f(0) && block(2) == f(2) && block(1) >= f(1) && block(1) < f(1) + 2) {
             /* We may place on our feet under certain circumstances */
             if(f(1) == block(1)) {
                 /* Allow placing on our feet if the block above our head is not an obstacle*/
-                return !blocks.is_obstacle[world.get_block(Vector3i(f(0), f(1) + 2, f(2)))];
+                return !blocks.is_obstacle[world.get_block(Vector3i(f(0), f(1) + 2, f(2))).type];
             } else {
                 /* We are never allowed to place on our head */
                 return false;
@@ -64,7 +64,7 @@ namespace konstructs {
     }
 
     Vector3f Player::update_position(int sz, int sx, float dt,
-                                     const World &world, const BlockData &blocks,
+                                     const World &world, const BlockTypeInfo &blocks,
                                      const float near_distance, const bool jump,
                                      const bool sneaking) {
         float vx = 0, vy = 0, vz = 0;
@@ -109,7 +109,7 @@ namespace konstructs {
                 // Get middle of block
                 Vector3i iPos((int)(position[0] + 0.5f), (int)(position[1]), (int)(position[2] + 0.5f));
                 ChunkData *chunk = world.chunk_at(iPos).get();
-                if(blocks.state[chunk->get(iPos)] == STATE_LIQUID) {
+                if(blocks.state[chunk->get(iPos).type] == STATE_LIQUID) {
                     dy = 5.5;
                 }
             }
@@ -146,7 +146,7 @@ namespace konstructs {
     }
 
     optional<pair<Block, Block>> Player::looking_at(const World &world,
-                                                    const BlockData &blocks) const {
+                                                    const BlockTypeInfo &blocks) const {
         optional<pair<Block, Block>> block(nullopt);
         float best = 0;
         const Vector3f v = camera_direction();
@@ -199,7 +199,7 @@ namespace konstructs {
         return mry;
     }
 
-    int Player::collide(const World &world, const BlockData &blocks,
+    int Player::collide(const World &world, const BlockTypeInfo &blocks,
                         const float near_distance, const bool sneaking) {
         int result = 0;
         float x = position[0];
@@ -219,44 +219,44 @@ namespace konstructs {
 
         try {
 
-            if (blocks.is_obstacle[world.get_block(feet())]) {
+            if (blocks.is_obstacle[world.get_block(feet()).type]) {
                 position[1] += 1.0f;
                 return 1;
             }
 
             if(sneaking) {
-                if (px < -pad && !blocks.is_obstacle[world.get_block(Vector3i(nx - 1, ny - 2, nz))]) {
+                if (px < -pad && !blocks.is_obstacle[world.get_block(Vector3i(nx - 1, ny - 2, nz)).type]) {
                     position[0] = nx - pad;
                 }
-                if (px > pad && !blocks.is_obstacle[world.get_block(Vector3i(nx + 1, ny - 2, nz))]) {
+                if (px > pad && !blocks.is_obstacle[world.get_block(Vector3i(nx + 1, ny - 2, nz)).type]) {
                     position[0] = nx + pad;
                 }
-                if (pz < -pad && !blocks.is_obstacle[world.get_block(Vector3i(nx, ny - 2, nz - 1))]) {
+                if (pz < -pad && !blocks.is_obstacle[world.get_block(Vector3i(nx, ny - 2, nz - 1)).type]) {
                     position[2] = nz - pad;
                 }
-                if (pz > pad && !blocks.is_obstacle[world.get_block(Vector3i(nx, ny - 2, nz + 1))]) {
+                if (pz > pad && !blocks.is_obstacle[world.get_block(Vector3i(nx, ny - 2, nz + 1)).type]) {
                     position[2] = nz + pad;
                 }
             }
             for (int dy = 0; dy < height; dy++) {
-                if (px < -pad && blocks.is_obstacle[world.get_block(Vector3i(nx - 1, ny - dy, nz))]) {
+                if (px < -pad && blocks.is_obstacle[world.get_block(Vector3i(nx - 1, ny - dy, nz)).type]) {
                     position[0] = nx - pad;
                 }
-                if (px > pad && blocks.is_obstacle[world.get_block(Vector3i(nx + 1, ny - dy, nz))]) {
+                if (px > pad && blocks.is_obstacle[world.get_block(Vector3i(nx + 1, ny - dy, nz)).type]) {
                     position[0] = nx + pad;
                 }
-                if (py < -pad && blocks.is_obstacle[world.get_block(Vector3i(nx, ny - dy - 1, nz))]) {
+                if (py < -pad && blocks.is_obstacle[world.get_block(Vector3i(nx, ny - dy - 1, nz)).type]) {
                     position[1] = ny - pad;
                     result = 1;
                 }
-                if (py > (pad - CAMERA_OFFSET) && blocks.is_obstacle[world.get_block(Vector3i(nx, ny - dy + 1, nz))]) {
+                if (py > (pad - CAMERA_OFFSET) && blocks.is_obstacle[world.get_block(Vector3i(nx, ny - dy + 1, nz)).type]) {
                     position[1] = ny + pad - CAMERA_OFFSET;
                     result = 1;
                 }
-                if (pz < -pad && blocks.is_obstacle[world.get_block(Vector3i(nx, ny - dy, nz - 1))]) {
+                if (pz < -pad && blocks.is_obstacle[world.get_block(Vector3i(nx, ny - dy, nz - 1)).type]) {
                     position[2] = nz - pad;
                 }
-                if (pz > pad && blocks.is_obstacle[world.get_block(Vector3i(nx, ny - dy, nz + 1))]) {
+                if (pz > pad && blocks.is_obstacle[world.get_block(Vector3i(nx, ny - dy, nz + 1)).type]) {
                     position[2] = nz + pad;
                 }
             }

--- a/src/player.h
+++ b/src/player.h
@@ -22,12 +22,12 @@ namespace konstructs {
         Vector3f camera() const;
         Vector3f camera_direction() const;
         Vector3i feet() const;
-        bool can_place(Vector3i block, const World &world, const BlockData &blocks);
+        bool can_place(Vector3i block, const World &world, const BlockTypeInfo &blocks);
         Vector3f update_position(int sz, int sx, float dt,
-                                 const World &world, const BlockData &blocks,
+                                 const World &world, const BlockTypeInfo &blocks,
                                  const float near_distance, const bool jump, const bool sneaking);
         optional<pair<Block, Block>> looking_at(const World &world,
-                                                const BlockData &blocks) const;
+                                                const BlockTypeInfo &blocks) const;
         void rotate_x(float speed);
         void rotate_y(float speed);
         int id;
@@ -36,7 +36,7 @@ namespace konstructs {
         float ry();
         Vector3f position;
     private:
-        int collide(const World &world, const BlockData &blocks,
+        int collide(const World &world, const BlockTypeInfo &blocks,
                     const float near_distance, const bool sneaking);
         float mrx;
         float mry;

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -44,7 +44,7 @@ namespace konstructs {
         requested.erase(pos);
     }
 
-    const char World::get_block(const Vector3i &block_pos) const {
+    const BlockData World::get_block(const Vector3i &block_pos) const {
         return chunks.at(chunked_vec_int(block_pos))->get(block_pos);
     }
 

--- a/src/world.h
+++ b/src/world.h
@@ -17,7 +17,7 @@ namespace konstructs {
         bool chunk_updated_since_requested(const Vector3i &pos) const;
         void delete_unused_chunks(const Vector3f position, const int radi);
         void insert(std::shared_ptr<ChunkData> data);
-        const char get_block(const Vector3i &block_pos) const;
+        const BlockData get_block(const Vector3i &block_pos) const;
         const std::shared_ptr<ChunkData> chunk_at(const Vector3i &block_pos) const;
         const std::shared_ptr<ChunkData> chunk(const Vector3i &chunk_pos) const;
         const std::vector<std::shared_ptr<ChunkData>> atAndAround(const Vector3i &pos) const;


### PR DESCRIPTION
- Add support for new block format with health
- Rename BlockData structure to BlockTypeInfo to more clearly state that
  it keeps information about the different BlockTypes
- Create new structure BlockData to replace "char" as the storage format
  for a single block in a chunk (1 byte to 4 byte per block)
- Update all parts of the code to use the new BlockData structure