### PR TITLE
Fix default server

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -672,7 +672,7 @@ void print_usage() {
 }
 
 int main(int argc, char ** argv) {
-    std::string hostname = "";
+    std::string hostname = "play.konstructs.org";
     std::string username = "";
     std::string password = "";
     bool debug_mode = false;


### PR DESCRIPTION
- Set default hostname to play.konstructs.org, fixes #183 