### PR TITLE
Return vacuum chunk instead of out of bounds

### DIFF
--- a/lib/include/block.h
+++ b/lib/include/block.h
@@ -3,7 +3,7 @@
 
 #include <Eigen/Geometry>
 
-#define VOID_BLOCK 0
+#define VACUUM_TYPE 0
 #define SOLID_TYPE 65535
 #define BLOCK_TYPES 65536
 #define MAX_HEALTH 2047

--- a/lib/include/chunk.h
+++ b/lib/include/chunk.h
@@ -29,7 +29,7 @@ namespace konstructs {
     public:
         ChunkData(const Vector3i _position, char *compressed, const int size, uint8_t *buffer);
         ChunkData(const Vector3i position, BlockData *blocks);
-        ChunkData();
+        ChunkData(const uint16_t type);
         ~ChunkData();
         BlockData get(const Vector3i &pos) const;
         std::shared_ptr<ChunkData> set(const Vector3i &pos, const BlockData &data) const;
@@ -40,6 +40,10 @@ namespace konstructs {
         const Vector3i position;
         BlockData *blocks;
     };
+
+    extern std::shared_ptr<ChunkData> SOLID_CHUNK;
+    extern std::shared_ptr<ChunkData> VACUUM_CHUNK;
+
 };
 
 #define CHUNK_FOR_EACH(blocks, ex, ey, ez, eb) \

--- a/lib/include/world.h
+++ b/lib/include/world.h
@@ -8,6 +8,8 @@
 #include "chunk.h"
 
 namespace konstructs {
+    using nonstd::optional;
+
     class World {
     public:
         int size() const;
@@ -15,7 +17,7 @@ namespace konstructs {
         void insert(std::shared_ptr<ChunkData> data);
         const BlockData get_block(const Vector3i &block_pos) const;
         const std::shared_ptr<ChunkData> chunk_at(const Vector3i &block_pos) const;
-        const std::shared_ptr<ChunkData> chunk(const Vector3i &chunk_pos) const;
+        const optional<std::shared_ptr<ChunkData>> chunk_opt(const Vector3i &chunk_pos) const;
         const std::vector<std::shared_ptr<ChunkData>> atAndAround(const Vector3i &pos) const;
         std::unordered_map<Vector3i, std::shared_ptr<ChunkData>, matrix_hash<Vector3i>>::const_iterator find(const Vector3i &pos) const;
         std::unordered_map<Vector3i, std::shared_ptr<ChunkData>, matrix_hash<Vector3i>>::const_iterator end() const;

--- a/lib/src/chunk.cpp
+++ b/lib/src/chunk.cpp
@@ -9,6 +9,9 @@
 namespace konstructs {
     using nonstd::nullopt;
 
+    std::shared_ptr<ChunkData> SOLID_CHUNK(std::make_shared<ChunkData>(SOLID_TYPE));
+    std::shared_ptr<ChunkData> VACUUM_CHUNK(std::make_shared<ChunkData>(VACUUM_TYPE));
+
     int chunked_int(int p) {
         if(p < 0) {
             return (p - CHUNK_SIZE + 1) / CHUNK_SIZE;
@@ -40,10 +43,10 @@ namespace konstructs {
             blocks[i].health = buffer[i * BLOCK_SIZE + 2] + ((buffer[i * BLOCK_SIZE + 3] & 0x07) << 8);
         }
     }
-    ChunkData::ChunkData() {
+    ChunkData::ChunkData(const uint16_t type) {
         blocks = new BlockData[CHUNK_SIZE*CHUNK_SIZE*CHUNK_SIZE];
         for(int i = 0; i < CHUNK_SIZE*CHUNK_SIZE*CHUNK_SIZE; i++) {
-            blocks[i].type = SOLID_TYPE;
+            blocks[i].type = type;
             blocks[i].health = MAX_HEALTH;
         }
     }

--- a/lib/src/chunk_factory.cpp
+++ b/lib/src/chunk_factory.cpp
@@ -24,7 +24,6 @@ namespace konstructs {
     static Vector3i RIGHT_FRONT(1, -1, 0);
     static Vector3i LEFT_BACK(-1, 1, 0);
     static Vector3i RIGHT_BACK(1, 1, 0);
-    static std::shared_ptr<ChunkData> SOLID_CHUNK(std::make_shared<ChunkData>());
 
     ChunkModelResult::ChunkModelResult(const Vector3i _position, const int components,
                                        const int _faces):
@@ -106,11 +105,14 @@ namespace konstructs {
 
     const std::shared_ptr<ChunkData>  get_chunk(const Vector3i &position,
                                                 const World &world) {
-        try {
-            return world.chunk(position);
-        } catch(std::out_of_range e) {
+        auto chunk = world.chunk_opt(position);
+
+        if(chunk) {
+            return chunk.value();
+        } else {
             return SOLID_CHUNK;
         }
+
     }
 
     const ChunkModelData create_model_data(const Vector3i &position,

--- a/lib/src/world.cpp
+++ b/lib/src/world.cpp
@@ -2,6 +2,8 @@
 
 namespace konstructs {
 
+    using nonstd::nullopt;
+
     int World::size() const {
         return chunks.size();
     }
@@ -24,15 +26,24 @@ namespace konstructs {
     }
 
     const BlockData World::get_block(const Vector3i &block_pos) const {
-        return chunks.at(chunked_vec_int(block_pos))->get(block_pos);
+        return chunk_at(block_pos)->get(block_pos);
     }
 
     const std::shared_ptr<ChunkData> World::chunk_at(const Vector3i &block_pos) const {
-        return chunks.at(chunked_vec_int(block_pos));
+        try {
+            return chunks.at(chunked_vec_int(block_pos));
+        } catch(std::out_of_range e) {
+            return VACUUM_CHUNK;
+        }
+
     }
 
-    const std::shared_ptr<ChunkData> World::chunk(const Vector3i &chunk_pos) const {
-        return chunks.at(chunk_pos);
+    const optional<std::shared_ptr<ChunkData>> World::chunk_opt(const Vector3i &chunk_pos) const {
+        try {
+            return chunks.at(chunk_pos);
+        } catch(std::out_of_range e)  {
+            return nullopt;
+        }
     }
 
     const std::vector<std::shared_ptr<ChunkData>> World::atAndAround(const Vector3i &pos) const {


### PR DESCRIPTION
- In world, when accessing chunks via block positions, return vacuum
  chunk instead of throwing exception when a chunk is not found
- Change "chunk" method to "chunk_opt" that returns an option of chunk
  data instead to be used when code needs to know if a chunk was not
  fetched yet