### PR TITLE
Cleanbuild snap

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -10,7 +10,7 @@ tar: konstructs-client.tar.bz2
 snap:
 	sed -i "s/version: 0/version: $(shell git describe --abbrev=0 --tags | tr -d v)/" snapcraft.yaml
 	snapcraft clean
-	snapcraft snap
+	snapcraft cleanbuild
 	sed -i "s/version: $(shell git describe --abbrev=0 --tags | tr -d v)/version: 0/" snapcraft.yaml
 
 build/konstructs:

--- a/package/konstructs-snap-wrapper
+++ b/package/konstructs-snap-wrapper
@@ -1,2 +1,39 @@
-export LIBGL_DRIVERS_PATH=$SNAP/usr/lib/x86_64-linux-gnu/dri
+#!/bin/bash
+
+echo "Welcome to Konstructs Client"
+echo "----------------------------"
+echo
+echo "Snap (snapcraft) is still a new package format and there are still"
+echo "problems with OpenGL applications, like Konstructs."
+echo
+echo "The system will output some debug information to help us to track"
+echo "down possible problems, please report crashes to:"
+echo "https://github.com/konstructs/client/issues"
+echo "Check for simular existing issues before you create a new one."
+echo
+echo "Some of your enviroment:"
+echo $LD_LIBRARY_PATH
+echo $LIBGL_DRIVERS_PATH
+echo $SNAP_LIBRARY_PATH
+echo $SNAP_REVISION
+echo $SNAP_ARCH
+echo $DISPLAY
+echo
+echo "A little about your system:"
+echo $DESKTOP_SESSION
+uname -a
+echo
+echo "List with libGL.so are available:"
+ldconfig -p | grep libGL.so
+ls $SNAP_LIBRARY_PATH
+echo
+echo
+echo "I will start the client now!"
+echo "-------------------------------------------------------"
+
+export LIBGL_DEBUG=verbose
+export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 $SNAP/konstructs
+
+echo "-------------------------------------------------------"
+echo "Did the client crash? If yes please report the problem."

--- a/package/snapcraft.yaml
+++ b/package/snapcraft.yaml
@@ -24,14 +24,14 @@ parts:
     after: [desktop-gtk3]
   client:
     plugin: cmake
-    source: ..
+    source: https://github.com/konstructs/client.git
     configflags: [-DCMAKE_INSTALL_PREFIX=/]
     build-packages:
-      - gcc-4.8
-      - g++-4.8
+      - build-essential
       - xorg-dev
       - cmake
       - libx11-dev
       - zlib1g-dev
+      - libgl1-mesa-dev
     stage-packages:
       - libgl1-mesa-dri


### PR DESCRIPTION
This is what I had to do to get a cleanbuild to compile, `gcc-4.8` and `g++-4.8` are probably redundant considering that cmake uses GCC 5.2 (or was it 5.3?) from `build-essential`.

What do you think @petterarvidsson, try to pin it to 4.8 or should we just use the latest available?

Another thought, considering that we can't include the the local checkout (`source: ..`) from a `cleanbuild`, maybe it makes more sense to move the snapcraft buildfiles to their own repo?