### PR TITLE
Working text printed at the top of screen.

### DIFF
--- a/lib/src/textures.cpp
+++ b/lib/src/textures.cpp
@@ -102,6 +102,8 @@ namespace konstructs {
         texture_path("health_bar.png", txtpth, KONSTRUCTS_PATH_SIZE);
         load_png_texture(txtpth);
 
+        // Set Active texture to GL_TEXTURE0, nanogui will use the active texture
+        glActiveTexture(GL_TEXTURE0);
     }
 
     tinyobj::shape_t load_player() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,12 +225,27 @@ public:
             glfwGetCursorPos(mGLFWWindow, &mx, &my);
             hud_shader.render(mSize.x(), mSize.y(), mx, my, hud, blocks);
             update_radius();
+            print_top_text();
         } else if(!menu_state) {
             show_menu(2, client.get_error_message());
         }
     }
 
 private:
+
+    /** This function uses nanovg to print text on top of the screen. This is
+     *  used for both the debug screen and messages sent from the server.
+     */
+    void print_top_text() {
+        int width, height;
+        glfwGetFramebufferSize(mGLFWWindow, &width, &height);
+
+        ostringstream os;
+        os << "Connected to " << hostname << " with user " << username;
+        nvgFontBlur(mNVGContext, 0.8f);
+        nvgFontSize(mNVGContext, 20.0f);
+        nvgTextBox(mNVGContext, 10, 20, width - 10, os.str().c_str(), '\0');
+    }
 
     int translate_button(int button) {
         switch(button) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,6 +90,7 @@ public:
         hud(17, 14, 9),
         menu_state(false),
         debug_mode(debug_mode),
+        debug_text_enabled(false),
         frame(0),
         click_delay(0) {
 
@@ -161,6 +162,8 @@ public:
             } else {
                 hide_menu();
             }*/
+        } else if (key == GLFW_KEY_F3 && action == GLFW_PRESS) {
+            debug_text_enabled = !debug_text_enabled;
         } else if (key == KONSTRUCTS_KEY_FLY
                    && action == GLFW_PRESS
                    && debug_mode) {
@@ -241,10 +244,14 @@ private:
         glfwGetFramebufferSize(mGLFWWindow, &width, &height);
 
         ostringstream os;
-        os << "Connected to " << hostname << " with user " << username;
+        if (debug_text_enabled) {
+            os << "Connected to " << hostname << " with user " << username << std::endl;
+        }
+
+        glActiveTexture(GL_TEXTURE0);
         nvgFontBlur(mNVGContext, 0.8f);
         nvgFontSize(mNVGContext, 20.0f);
-        nvgTextBox(mNVGContext, 10, 20, width - 10, os.str().c_str(), '\0');
+        nvgTextBox(mNVGContext, 10, 20, width - 10, os.str().c_str(), NULL);
     }
 
     int translate_button(int button) {
@@ -734,6 +741,7 @@ private:
     double last_frame;
     bool menu_state;
     bool debug_mode;
+    bool debug_text_enabled;
     nanogui::Window *window;
     uint32_t frame;
     uint32_t faces;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #endif
 #include <nanogui/glutil.h>
 #include <iostream>
+#include <iomanip>
 #include <vector>
 #include <memory>
 #include <utility>
@@ -245,7 +246,16 @@ private:
 
         ostringstream os;
         if (debug_text_enabled) {
-            os << "Connected to " << hostname << " with user " << username << std::endl;
+            double frame_fps = 1.15 / frame_time;
+            os << std::fixed << std::setprecision(2);
+            os << "Server: " << hostname << " user: " << username << " x: " << player.position(0) << " y: " << player.position(
+                   1) << " z: " << player.position(2) << std::endl;
+            os << "View distance: " << view_distance << " (" << radius << "/" << client.get_loaded_radius() << ") faces: " <<
+               faces << "(" << max_faces << ") FPS: " << fps.fps << "(" << frame_fps << ")" << endl;
+            os << "Chunks: " << world.size() << " models: " << chunk_shader.size() << endl;
+            os << "Model factory, waiting: " << model_factory.waiting() << " created: " << model_factory.total_created() <<
+               " empty: " << model_factory.total_empty() << " total: " <<  model_factory.total() << endl;
+
         }
 
         glActiveTexture(GL_TEXTURE0);
@@ -287,15 +297,6 @@ private:
             int new_radius = (int)(view_distance / (float)CHUNK_SIZE) + 1;
             radius = new_radius;
             client.set_radius(radius);
-        }
-
-        if(debug_mode && frame % 6 == 0) {
-            double frame_fps = 1.15 / frame_time;
-            cout << "View distance: " << view_distance << " (" << radius << "/" << client.get_loaded_radius() << ") faces: " <<
-                 faces << "(" << max_faces << ") FPS: " << fps.fps << "(" << frame_fps << ")" << endl;
-            cout << "Chunks: " << world.size() << " models: " << chunk_shader.size() << endl;
-            cout << "Model factory, waiting: " << model_factory.waiting() << " created: " << model_factory.total_created() <<
-                 " empty: " << model_factory.total_empty() << " total: " <<  model_factory.total() << endl;
         }
     }
 


### PR DESCRIPTION
![screenshot at 2016-11-13 19 45 02](https://cloud.githubusercontent.com/assets/16388/20247946/d5665152-a9d9-11e6-815b-067b471b5c79.png)

@petterarvidsson 
What do you think? `nvgTextBox(..)` will line wrap at the end of screen.

What I like to add to this PR are:
* Toggle the debug text on/off with `F3`
* Read last 10 messages from a Vector and display them.
* Populate the above Vector with messages sent from the server.
* Bind a nanogui text input dialog to `T` and send the as a chat message to the server.

Sounds like a good approach?