### PR TITLE
Add snap build badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Konstructs
 
-[![Join the chat at https://gitter.im/konstructs/client](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/konstructs/client?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/konstructs/client.svg?branch=master)](https://travis-ci.org/konstructs/client)
+[![Join the chat at https://gitter.im/konstructs/client](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/konstructs/client?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/konstructs/client.svg?branch=master)](https://travis-ci.org/konstructs/client) [![Snap Status](https://build.snapcraft.io/badge/konstructs/client.svg)](https://build.snapcraft.io/user/konstructs/client)
 
 This is a Infiniminer/Minecraft inspired multiplayer open source game, focused on massive gameplay. We are trying to remove some of the limitations built into the original games.
 


### PR DESCRIPTION
Add the badge from https://build.snapcraft.io to the README.

I have also setup so master is released to the edge channel for `konstructs-client` so to test master it's just a `sudo snap install --edge konstructs-client` away! Note: The version is incorrect because we do not use annotated tags, this will fix it self when we do release 10 with an annotated tag (or snapcraft get support for lightweight tags, whatever happens first).